### PR TITLE
Enable 3.11 support

### DIFF
--- a/strobelight/bpf_lib/python/discovery/OffsetResolver.cpp
+++ b/strobelight/bpf_lib/python/discovery/OffsetResolver.cpp
@@ -175,8 +175,9 @@ const OffsetConfig& OffsetResolver::getHeaderOffsetsForVersion(
           {std::string_view("cpython-38"), kPy38OffsetConfig},
           {std::string_view("cpython-39"), kPy39OffsetConfig},
           {std::string_view("cpython-310"), kPy310OffsetConfig},
+          {std::string_view("cpython-311"), kPy311OffsetConfig},
           {std::string_view("cpython-312"), kPy312OffsetConfig},
-          {kPyOffsetDefaultKey, kPy38OffsetConfig}};
+          {kPyOffsetDefaultKey, kPy312OffsetConfig}};
 
   auto oc = pythonOffsets.find(versionString);
   if (oc == pythonOffsets.end()) {

--- a/strobelight/bpf_lib/python/discovery/Py311Offsets.cpp
+++ b/strobelight/bpf_lib/python/discovery/Py311Offsets.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "strobelight/bpf_lib/python/include/OffsetConfig.h"
+
+namespace facebook::strobelight::bpf_lib {
+
+// clang-format off
+//
+// Python 3.11 introduces the new _PyInterpreterFrame structure for improved
+// performance, but with different field layout than Python 3.12.
+//
+// Key differences from 3.10:
+// - Uses PyThreadState_cframe instead of PyThreadState_frame
+// - Uses _PyInterpreterFrame instead of PyFrameObject
+// - Frame walking via PyInterpreterFrame_previous instead of PyFrameObject_back
+//
+// Key differences from 3.12:
+// - _PyCFrame.current_frame at offset 8 (3.12 has it at 0 - removed use_tracing)
+// - PyInterpreterFrame has different field ordering (f_code at 32 vs 0)
+// - PyInterpreterFrame_previous at offset 48 (3.12 has it at 8)
+//
+// Offsets measured from Python 3.11.14 on x86_64 Linux
+//
+// clang-format on
+
+/*
+Items that no longer exist in 3.11 (compared to 3.10):
+- PyThreadState_frame, replaced by PyThreadState_cframe and _PyCFrame_current_frame
+- PyFrameObject_back, replaced by PyInterpreterFrame_previous
+- PyFrameObject_code, replaced by PyInterpreterFrame_code
+- PyFrameObject_lasti, replaced by PyInterpreterFrame_prev_instr
+- PyFrameObject_localsplus, replaced by PyInterpreterFrame_localsplus
+
+Items that differ from 3.12:
+- _PyCFrame still has use_tracing field (removed in 3.12)
+- PyInterpreterFrame layout not yet optimized (reorganized in 3.12)
+*/
+
+extern const OffsetConfig kPy311OffsetConfig = [] {
+  OffsetConfig config;
+  config.PyObject_type = 8; // offsetof(PyObject, ob_type)
+  config.PyTypeObject_name = 24; // offsetof(PyTypeObject, tp_name)
+
+  // cframe wraps around frame (introduced in 3.11)
+  config.PyThreadState_cframe = 56; // offsetof(PyThreadState, cframe)
+  config.PyThreadState_thread = 152; // offsetof(PyThreadState, thread_id)
+
+  // _PyCFrame structure (still has use_tracing field in 3.11)
+  config._PyCFrame_current_frame = 8; // offsetof(_PyCFrame, current_frame)
+
+  // _PyInterpreterFrame structure (different layout than 3.12)
+  config.PyInterpreterFrame_code = 32; // offsetof(_PyInterpreterFrame, f_code)
+  config.PyInterpreterFrame_previous =
+      48; // offsetof(_PyInterpreterFrame, previous)
+  config.PyInterpreterFrame_localsplus =
+      72; // offsetof(_PyInterpreterFrame, localsplus)
+  config.PyInterpreterFrame_prev_instr =
+      56; // offsetof(_PyInterpreterFrame, prev_instr)
+
+  // Code object offsets
+  config.PyCodeObject_co_flags = 48; // offsetof(PyCodeObject, co_flags)
+  config.PyCodeObject_filename = 112; // offsetof(PyCodeObject, co_filename)
+  config.PyCodeObject_name = 120; // offsetof(PyCodeObject, co_name)
+  config.PyCodeObject_qualname = 128; // offsetof(PyCodeObject, co_qualname)
+  config.PyCodeObject_linetable = 136; // offsetof(PyCodeObject, co_linetable)
+  config.PyCodeObject_firstlineno =
+      72; // offsetof(PyCodeObject, co_firstlineno)
+
+  // Other object offsets
+  config.PyTupleObject_item = 24; // offsetof(PyTupleObject, ob_item)
+  config.PyBytesObject_data = 32; // offsetof(PyBytesObject, ob_sval)
+  config.PyVarObject_size = 16; // offsetof(PyVarObject, ob_size)
+  config.String_data = 48; // sizeof(PyASCIIObject)
+
+  // TLS offset for getting per-thread state
+  // TLSKey_offset = offsetof(_PyRuntimeState, gilstate) + offsetof(_gilstate_runtime_state, autoTSSkey) + offsetof(Py_tss_t, _key)
+  config.TLSKey_offset = 596;
+  // TCurrentState_offset = offsetof(_PyRuntimeState, gilstate) + offsetof(_gilstate_runtime_state, tstate_current)
+  config.TCurrentState_offset = 576;
+  config.PyGIL_offset = 376;
+  config.PyGIL_last_holder = 368;
+
+  // Version
+  config.PyVersion_major = 3;
+  config.PyVersion_minor = 11;
+  config.PyVersion_micro = 0;
+
+  return config;
+}();
+
+} // namespace facebook::strobelight::bpf_lib

--- a/strobelight/bpf_lib/python/discovery/PyOffsets.h
+++ b/strobelight/bpf_lib/python/discovery/PyOffsets.h
@@ -12,6 +12,9 @@ extern const OffsetConfig kCinder310OffsetConfig;
 // @dep=//strobelight/bpf_lib/python/discovery:py312_offset
 extern const OffsetConfig kPy312OffsetConfig;
 
+// @dep=//strobelight/bpf_lib/python/discovery:py311_offset
+extern const OffsetConfig kPy311OffsetConfig;
+
 // @dep=//strobelight/bpf_lib/python/discovery:py310_offset
 extern const OffsetConfig kPy310OffsetConfig;
 

--- a/strobelight/bpf_lib/python/discovery/PyProcessDiscovery.cpp
+++ b/strobelight/bpf_lib/python/discovery/PyProcessDiscovery.cpp
@@ -112,7 +112,7 @@ void PyProcessDiscovery::discoverAndConfigure(
         strobelight_lib_print(
             STROBELIGHT_LIB_INFO,
             fmt::format("No python runtime info for process {}", pid).c_str());
-        return;
+        continue;
       }
 
       bool targeted = true;

--- a/strobelight/bpf_lib/python/pystacks/pystacks.bpf.c
+++ b/strobelight/bpf_lib/python/pystacks/pystacks.bpf.c
@@ -511,7 +511,7 @@ static __always_inline void* get_code_ptr(
   }
   // If we aren't using shadow frames then the frame pointer is a PyFrameObject
   else {
-    if (offsets->PyVersion_major >= 3 && offsets->PyVersion_minor >= 12) {
+    if (offsets->PyVersion_major >= 3 && offsets->PyVersion_minor >= 11) {
       result = bpf_probe_read_user_task(
           &code_ptr,
           sizeof(void*),
@@ -564,7 +564,7 @@ __noinline bool pystacks_get_frame_data(int pid) {
   int ret_code = 0;
 
   // read next PyFrameObject/PyShadowFrame pointer
-  if (offsets->PyVersion_major >= 3 && offsets->PyVersion_minor >= 12) {
+  if (offsets->PyVersion_major >= 3 && offsets->PyVersion_minor >= 11) {
     ret_code = bpf_probe_read_user_task(
         &state->frame_ptr,
         sizeof(void*),

--- a/strobelight/bpf_lib/python/pystacks/pystacks.cpp
+++ b/strobelight/bpf_lib/python/pystacks/pystacks.cpp
@@ -39,9 +39,14 @@ struct stack_walker_run {
 
   bool manualSymbolRefresh_{};
 
-  std::shared_ptr<facebook::pid_info::SharedPidInfoCache> pidInfoCache_;
+  // IMPORTANT: pyProcessDiscovery_ must be declared before pidInfoCache_
+  // because C++ destroys members in reverse declaration order.
+  // pyProcessDiscovery_ holds references to OffsetResolver objects that may
+  // be managed by pidInfoCache_, so pyProcessDiscovery_ must be destroyed first
+  // while pidInfoCache_ is still valid.
   std::shared_ptr<facebook::strobelight::bpf_lib::python::PyProcessDiscovery>
       pyProcessDiscovery_;
+  std::shared_ptr<facebook::pid_info::SharedPidInfoCache> pidInfoCache_;
   std::vector<std::string> moduleIdentifierKeywords_;
 
   std::shared_mutex mapsMutex_;


### PR DESCRIPTION
We use python 3.11 in Anthropic, which has different offsets than the default (3.8). This adds the necessary offsets and changes to the BPF side to enable 3.11 support for pystacks. It also updates the default to 3.12, as anything more modern is going to be more likely to not be 3.8.